### PR TITLE
Don't bomb out when class lacks a constructor

### DIFF
--- a/src/inject-helper.js
+++ b/src/inject-helper.js
@@ -12,7 +12,7 @@ export function getInjectInfo(classDeclaration, sourceCode) {
 	return {
 		ctor: {
 			node: ctor,
-			params: ctor.value.params,
+			params: ctor ? ctor.value.params : null,
 		},
 		injects,
 	};

--- a/test/rules/inject-type.spec.js
+++ b/test/rules/inject-type.spec.js
@@ -10,6 +10,7 @@ ruleTester.run('inject-type', rule, {
 		{ code: '@inject(1) class Foo { constructor(a) {} } @inject(2) class Bar { constructor(b){} }', options: [ 'decorator' ] },
 		{ code: 'class Foo { static inject() {return [1]; } constructor(a) {} }', options: [ 'method' ] },
 		{ code: 'class Foo { static inject = [1]; constructor(a) {} }', options: [ 'property' ] },
+		{ code: 'class Foo {}', options: [ 'property' ] },
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Analyzing classes which don't have a constructor was causing the whole eslint run to exit due to an exception.
