### PR TITLE
fix(inject-rule): Fixing error when no constructor is defined

### DIFF
--- a/src/rules/inject-matches-ctor.js
+++ b/src/rules/inject-matches-ctor.js
@@ -14,7 +14,7 @@ export default function injectMatchesCtorRule(context) {
 				context.report(duplicateInject.node, 'Unexpected duplicate inject.');
 			}
 
-			const ctorParamsLength = injectInfo.ctor.params.length;
+			const ctorParamsLength = injectInfo.ctor.params ? injectInfo.ctor.params.length : 0;
 			if (injectElement.deps.length !== ctorParamsLength) {
 				context.report(injectElement.node, 'Constructor parameters do not match injected dependencies.');
 			}


### PR DESCRIPTION
At least with babel >= 7.0.0 there is an error thrown when a class defines an inject but actually doesn't define a constructor at all. The value of injectInfo.ctor is `{ node: undefined, params: null }` which leads to the error `Cannot read property 'length' of null`
