### PR TITLE
chore(mocha): use test/mocha.opts file to specify babel loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "npm run lint && npm run test && rm -rf dist && babel src --out-dir dist",
-    "test": "babel-node node_modules/.bin/isparta cover --report text-summary --report lcov node_modules/mocha/bin/_mocha -- --recursive",
+    "test": "node node_modules/isparta/bin/isparta cover --report text-summary --report lcov node_modules/mocha/bin/_mocha -- --recursive",
     "lint": "eslint src/ test/",
     "ci": "npm run build && cat coverage/lcov.info | node_modules/.bin/coveralls",
     "patch": "release patch",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+  --compilers js:babel-register


### PR DESCRIPTION
Avoids the need to run babel-node directly.

Allows calling `mocha test/rules/<test.spec>` directly.