### PR TITLE
chore(all): add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules/
 npm-debug.log
 coverage/
+package-lock.json


### PR DESCRIPTION
package-lock.json should *probably* be in git, but since it isn't currently and it leaves me a file uncommitted decided to ignore it instead.